### PR TITLE
Handle empty options, and a rename-only git diff

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,7 +298,7 @@ module.exports = {
 		return pair.combine()
 	},
 
-	splitPatch(patch, options) {
+	splitPatch(patch, options = {}) {
 		let parsedPatch = diff.parsePatch(patch)
 		let output = []
 
@@ -308,6 +308,9 @@ module.exports = {
 		}
 
 		for(let patch of parsedPatch) {
+			if (!patch.oldFileName || !patch.newFileName) {
+				continue
+			}
 			let pair = new Pair(
 				new HunkHeader(),
 				new HunkHeader()


### PR DESCRIPTION
If you have a git diff with only renames, then it was throwing an error. I guess the correcter fix is to make this https://github.com/kpdecker/jsdiff parse git diffs with renames. But that's a lot more work.